### PR TITLE
.csproj file for multitargeting

### DIFF
--- a/SentinelCore.csproj
+++ b/SentinelCore.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>2.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>2.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This csproj file is of the new format and multi -  targets .NET 4.6.1 as well as .NET Core 2.0
Open it directly in visual studio. Make sure it resides next to the code files. May need to do a dotnet restore. Make sure the appropriate .NET Framework targeting pack is installed

The following attribute <GenerateAssemblyInfo>false</GenerateAssemblyInfo> prevents duplicate AssemblyInfo attribute errors